### PR TITLE
convert message bodies to json before sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mbs-messaging-umb
 ==================
 
-A plugin for the Module Build System to support sending and receiving messages from the Unified Message Bus
+A plugin for the Module Build Service to support sending and receiving messages from the Unified Message Bus
 -----------------------------------------------------
 
 The [Module Build Service](https://pagure.io/fm-orchestrator/) is a system

--- a/mbs_messaging_umb/publisher.py
+++ b/mbs_messaging_umb/publisher.py
@@ -22,6 +22,7 @@
 # Written by Mike Bonnet <mikeb@redhat.com>
 
 
+import json
 import logging
 import ssl
 import uuid
@@ -77,6 +78,7 @@ class StompPublisher(object):
         conn.connect(wait=True)
         self.log.debug('Connected to %s', conn.get_host_and_port())
         dest = '.'.join([load_config().dest_prefix, topic])
+        msg = json.dumps(msg)
         headers = {
             'destination': dest,
             'content-type': 'text/json',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('test-requirements.txt') as f:
 
 setup(
     name='mbs-messaging-umb',
-    description='A plugin for the Module Build System to support sending '
+    description='A plugin for the Module Build Service to support sending '
     'and receiving messages from the Unified Message Bus',
     version='0.0.1',
     classifiers=[


### PR DESCRIPTION
The message dicts need to be converted to json before sending via STOMP.