### PR TITLE
Fix KojiBuildChange mapping, and some README/MANIFEST fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-exclude *.pyc *.pyo
 include LICENSE
-include README.rst
+include README.md
 include requirements.txt
 include test-requirements.txt
 recursive-include conf config.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include LICENSE
 include README.md
 include requirements.txt
 include test-requirements.txt
+recursive-include tests *.py
 recursive-include conf config.py

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ which can be treated as discrete units for testing and deployment.
 
 The MBS was originally built to work with [fedmsg](http://fedmsg.com).
 However, it has a pluggable system for message parsing and publising. This
-package provides a plugin which that enables fully config-driven message
-parsing, and publishing using STOMP.
+package provides a plugin that enables fully config-driven message parsing,
+and publishing using STOMP.
 
 Build Status
 ------------

--- a/conf/config.py
+++ b/conf/config.py
@@ -15,7 +15,6 @@ message_mapping = {
         'build_name': 'body.info.name',
         'build_version': 'body.info.version',
         'build_release': 'body.info.release',
-        'module_build_id': 'body.info.id',
     },
     'KojiTagChange': {
         'matches': ['/topic/VirtualTopic.eng.brew.build.tag'],


### PR DESCRIPTION
KojiBuildChange messages don't include module_build_id, so remove it from the mapping. Also, a couple fixes to the README.md and MANIFEST.in.